### PR TITLE
Bugfix with internal caching

### DIFF
--- a/fields/field.selectbox_link.php
+++ b/fields/field.selectbox_link.php
@@ -133,8 +133,8 @@
 		private function __findPrimaryFieldValueFromRelationID($entry_id){
 			$field_id = $this->findFieldIDFromRelationID($entry_id);
 
-			if (!isset(self::$cacheFields[$field_id])) {
-				self::$cacheFields[$field_id] = $this->_engine->Database->fetchRow(0, "
+			if (!isset(self::$cacheFields[$this->get('id').'_'.$entry_id.'_'.$field_id])) {
+				self::$cacheFields[$this->get('id').'_'.$entry_id.'_'.$field_id] = $this->_engine->Database->fetchRow(0, "
 					SELECT
 						f.id,
 						s.name AS `section_name`,
@@ -152,15 +152,15 @@
 				");
 			}
 
-			$primary_field = self::$cacheFields[$field_id];
+			$primary_field = self::$cacheFields[$this->get('id').'_'.$entry_id.'_'.$field_id];
 
 			if(!$primary_field) return NULL;
 
 			$fm = new FieldManager($this->_Parent);
 			$field = $fm->fetch($field_id);
 
-			if (!isset(self::$cacheValues[$entry_id])) {
-				self::$cacheValues[$entry_id] = $this->_engine->Database->fetchRow(0, sprintf("
+			if (!isset(self::$cacheValues[$this->get('id').'_'.$entry_id.'_'.$field_id])) {
+				self::$cacheValues[$this->get('id').'_'.$entry_id.'_'.$field_id] = $this->_engine->Database->fetchRow(0, sprintf("
 						SELECT *
 				 		FROM `tbl_entries_data_%d`
 				 		WHERE `entry_id` = %d
@@ -169,7 +169,7 @@
 				", $field_id, $entry_id));
 			}
 
-			$data = self::$cacheValues[$entry_id];
+			$data = self::$cacheValues[$this->get('id').'_'.$entry_id.'_'.$field_id];
 
 			if(empty($data)) return null;
 
@@ -256,8 +256,8 @@
 		public function findFieldIDFromRelationID($id){
 			if(is_null($id)) return NULL;
 
-			if (isset(self::$cacheRelations[$id])) {
-				return self::$cacheRelations[$id];
+			if (isset(self::$cacheRelations[$this->get('id').'_'.$id])) {
+				return self::$cacheRelations[$this->get('id').'_'.$id];
 			}
 
 			try{
@@ -274,7 +274,7 @@
 				return NULL;
 			}
 
-			self::$cacheRelations[$id] = $field_id;
+			self::$cacheRelations[$this->get('id').'_'.$id] = $field_id;
 
 			return $field_id;
 		}


### PR DESCRIPTION
Hi,

I fixed a bug the occured with the internal caching. It had my mind buzzing for a couple of days. Here is what happened:
- I have three sections: A, B and C.
- Section A has two fields: 'Name' and 'Location'.
- Section B and C have a selectbox link field to the entries of section A.
- Section B chooses as 'value' in the section editor the field 'Name' of section A.
- Section C chooses as 'value' in the section editor the field 'Location' of section A.
- I create two datasources: datasource B with the entries of section B, and datasource C with the entries of section C.
- I create a page and add these two datasource to the page.

Now the expected result is:
- Datasource B shows the items of the selectbox link field with value 'Name'.
- Datasource C shows the items of the selectbox link field with value 'Location'.

But what happens is that both datasource B and C show the items with value 'Name'. This is wrong!

The error occurs because of the `self::$cacheRelations`, `self::$cacheFields` and `self::$cacheValues`-fields in the `field.selectbox_link.php`-file. These arrays only use an ID as key for caching. Because of this method, whenever an ID is used twice (for example, the entry in the above example is shown as well in datasource B as in datasource C) it no longer looks for the correct value, but instead prefers the cached result over it.

I've fixed this by changing the key of the caching arrays to a more solid key which combines the ID of the field and the ID of the relation or the entry (depends on each array).

Kind regards,

Giel Berkers
