### PR TITLE
Fixed value in `prepareTableValue()`.

### DIFF
--- a/fields/field.selectbox_link.php
+++ b/fields/field.selectbox_link.php
@@ -524,7 +524,7 @@
 			$output = '';
 
 			foreach($result as $item){
-				$link = Widget::Anchor($item['value'], sprintf('%s/publish/%s/edit/%d/', SYMPHONY_URL, $item['section_handle'], $item['id']));
+				$link = Widget::Anchor(is_null($item['value']) ? '' : $item['value'], sprintf('%s/publish/%s/edit/%d/', SYMPHONY_URL, $item['section_handle'], $item['id']));
 				$output .= $link->generate() . ' ';
 			}
 


### PR DESCRIPTION
Without this fix, when changing the settings of the field (`Values`), empty data would be sent to `Widget::Anchor` thus triggering an invalid type error.
