### PR TITLE
Make $hash truly unique.

### DIFF
--- a/fields/field.selectbox_link.php
+++ b/fields/field.selectbox_link.php
@@ -223,7 +223,7 @@
 			$relation_id = array_filter($relation_id);
 			if(empty($relation_id)) return array();
 
-			$hash = md5(serialize($relation_id));
+			$hash = md5(serialize($relation_id).$this->get('element_name'));
 
 			if(!isset(self::$cache[$hash]['relation_data'])) {
 				$relation_ids = Symphony::Database()->fetch(sprintf("


### PR DESCRIPTION
If I have more than one SBL in section A pointing to field B1 in section B, the values of entries for all these SBLs will be the same as #1 SBL because of non-unique hash.

Adding field handle to the hash ensures true uniqueness.
