### PR TITLE
Show a message when there are no entries in a section (#18)

### DIFF
--- a/fields/field.selectbox_link.php
+++ b/fields/field.selectbox_link.php
@@ -504,8 +504,12 @@
 			if(!empty($states)){
 				foreach($states as $s){
 					$group = array('label' => $s['name'], 'options' => array());
-					foreach($s['values'] as $id => $v){
-						$group['options'][] = array($id, in_array($id, $entry_ids), General::sanitize($v));
+					if (count($s['values']) == 0) {
+						$group['options'][] = array(null, false, __('None found.'), null, null, array('disabled' => 'disabled'));
+					} else {
+						foreach($s['values'] as $id => $v){
+							$group['options'][] = array($id, in_array($id, $entry_ids), General::sanitize($v));
+						}
 					}
 					$options[] = $group;
 				}


### PR DESCRIPTION
Had no problems with this in multiple test scenarios and other related extensions seem to cooperate nicely with this as well. The Multiselect to Checkboxes extension might have a problem with this but it's marked as deprecated so I wouldn't worry about it.
