### PR TITLE
Make sure arrays of value wont crash the field

### DIFF
--- a/fields/field.selectbox_link.php
+++ b/fields/field.selectbox_link.php
@@ -116,6 +116,13 @@
 					if(is_array($results) && !empty($results)){
 						$related_values = $this->findRelatedValues($results);
 						foreach($related_values as $value){
+							// If this field permits multiple records per entry
+							// (or the data is corrupted), use the first record.
+							// This prevents a Symphony error and also prevent a case where
+							// The string `Array` was showing.
+							if (is_array($value['value'])) {
+								$value['value'] = $value['value'][0];
+							}
 							$group['values'][$value['id']] = $value['value'];
 						}
 					}


### PR DESCRIPTION
This is related to this issue: https://github.com/symphonycms/symphony-2/pull/1917

If a field stores multiple records per entry, the select box fails.

This fix prevents that.
