### PR TITLE
Prevent Circular lookup on frontend

### DIFF
--- a/fields/field.selectbox_link.php
+++ b/fields/field.selectbox_link.php
@@ -123,7 +123,16 @@
 					$values[] = $group;
 				}
 			}
+			
+			//Remove current entry_id being edited from returned options to prevent circular lookup
+			//See https://github.com/symphonycms/selectbox_link_field/issues/38
+			$page = Administration::instance()->Page;
+        		$context = $page->getContext();
 
+		        if($context['page'] == 'edit'){
+		            unset($values[0]['values'][$context['entry_id']]);
+		        }
+			
 			return $values;
 		}
 


### PR DESCRIPTION
https://github.com/symphonycms/selectbox_link_field/issues/38

When an entry is linked to itself using SBL a circular lookup happens on the frontend and page never renders.

Is the submitted code correctly referencing the array correctly? not 100% sure if this is correct, but could someone take a look at it?
