### PR TITLE
Remove current entry_id from options list

### DIFF
--- a/fields/field.selectbox_link.php
+++ b/fields/field.selectbox_link.php
@@ -120,7 +120,9 @@
 						}
 					}
 					
-					unset($group['values'][$entry_id]);
+					if(!is_null($entry_id) && isset($group['values'][$entry_id])){
+						unset($group['values'][$entry_id]);
+					}
 					$values[] = $group;
 				}
 			}


### PR DESCRIPTION
Fix to prevent circular lookup with cleaner approach to code: https://github.com/symphonycms/selectbox_link_field/issues/38

@brendo is this what you meant? still using unset at end of $group array right?
