### PR TITLE
Relationship is required

### DIFF
--- a/fields/field.selectbox_link.php
+++ b/fields/field.selectbox_link.php
@@ -396,7 +396,8 @@
 			$label->appendChild(
 				Widget::Select('fields['.$this->get('sortorder').'][related_field_id][]', $options, array(
 					'multiple' => 'multiple',
-					'class' => 'js-fetch-sections'
+					'class' => 'js-fetch-sections',
+					'data-required' => 'true',
 				))
 			);
 


### PR DESCRIPTION
This add the data-required attribute in order to
remove the 'none' option in the select box. This fix requires a core change,
which is https://github.com/symphonycms/symphony-2/pull/2114
