### PR TITLE
Follow up of #66

### DIFF
--- a/fields/field.selectbox_link.php
+++ b/fields/field.selectbox_link.php
@@ -624,7 +624,7 @@
 			}
 
 			if(!is_null($link)){
-				$link->setValue($this->preparePlainTextValue($data, $entry_id));
+				$link->setValue($this->prepareReadableValue($data, $entry_id, true, __('None')));
 				return $link->generate();
 			}
 
@@ -639,9 +639,9 @@
 			return trim($output, ', ');
 		}
 
-		public function preparePlainTextValue($data, $entry_id = null, $truncate = false, $defaultValue = null) {
+		public function prepareTextValue($data, $entry_id = null) {
 			if(!is_array($data) || (is_array($data) && !isset($data['relation_id']))) {
-				return parent::preparePlainTextValue($data, $entry_id, $truncate, $defaultValue);
+				return parent::prepareTextValue($data, $entry_id);
 			}
 
 			if(!is_array($data['relation_id'])){


### PR DESCRIPTION
This aligns the field with the latest changes in
symphonycms/symphony-2#2100

It now implements `prepareTextValue` but delegates reads to the default
`prepareReadableValue` implementation that will properly format
our implementation of textValue.
