### PR TITLE
Check if $data is array before checking isset

### DIFF
--- a/fields/field.selectbox_link.php
+++ b/fields/field.selectbox_link.php
@@ -453,7 +453,7 @@
 		public function checkPostFieldData($data, &$message, $entry_id = null){
 			$message = NULL;
 
-			$data = isset($data['relation_id'])
+			$data = is_array($data) && isset($data['relation_id'])
 				? array_filter($data['relation_id'])
 				: $data;
 


### PR DESCRIPTION
I do not know why, but on my setup, when $data is a string, isset would
return true. Also checking if $data is an array fixes it and should not
cause damage since the only thing we do with tha array is filter it.
