### PR TITLE
Revert back to $data if no relation_id is set

### DIFF
--- a/fields/field.selectbox_link.php
+++ b/fields/field.selectbox_link.php
@@ -453,9 +453,11 @@
 		public function checkPostFieldData($data, &$message, $entry_id = null){
 			$message = NULL;
 
-			$data = is_array($data) && isset($data['relation_id'])
-				? array_filter($data['relation_id'])
-				: $data;
+			if (is_array($data)) {
+				$data = isset($data['relation_id'])
+					? array_filter($data['relation_id'])
+					: array_filter($data);
+			}
 
 			if ($this->get('required') == 'yes' && (empty($data))) {
 				$message = __('‘%s’ is a required field.', array($this->get('label')));


### PR DESCRIPTION
This should fix #70 while keeping the is_array check
