### PR TITLE
Added canPrePopulate() method. Fixes #87

### DIFF
--- a/fields/field.selectbox_link.php
+++ b/fields/field.selectbox_link.php
@@ -35,6 +35,10 @@
             return true;
         }
 
+        public function canPrePopulate() {
+            return true;
+        }
+
         public function isSortable(){
             $relatedFieldsId = $this->getRelatedFieldsId();
             foreach ($relatedFieldsId as $relatedFieldId) {


### PR DESCRIPTION
Relates to https://github.com/symphonycms/selectbox_link_field/issues/87 and https://github.com/symphonycms/symphony-2/pull/2751

Prior to this change in 2.7.x, the Publish: New page never actually checked to see if a field was allowed to prepopulate. The SBL field was missing the `canPrePopulate` method, so meant prepopulating stopped working.

This PR added that method in, bringing SBL field up to date with new behaviour in 2.7.x.